### PR TITLE
Add option to configure event propagation mode

### DIFF
--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -516,6 +516,13 @@
                             Create dialog component in the root view container instead the elements view container.<br>
                         </td>
                     </tr>
+                    <tr>
+                        <td>cpUseCapture</td>
+                        <td>
+                            <b>false</b>, true<br>
+                            Set event propagation mode to useCapture.<br>
+                        </td>
+                    </tr>
                 </tbody>
             </table>
         </div>

--- a/src/lib/color-picker.component.html
+++ b/src/lib/color-picker.component.html
@@ -1,7 +1,7 @@
 <div class="color-picker" [hidden]="!show" [style.visibility]="this.hidden ? 'hidden' : 'visible'" [style.height.px]="cpHeight" [style.width.px]="cpWidth" [style.top.px]="top" [style.left.px]="left" [style.position]="position" #dialogPopup>
     <div *ngIf="cpDialogDisplay=='popup'" class="arrow arrow-{{cpPosition}}" [style.top.px]="arrowTop"></div>
 
-    <div [slider] [style.background-color]="hueSliderColor" [rgX]="1" [rgY]="1" (newValue)="setSaturationAndBrightness($event)" class="saturation-lightness">
+    <div [slider] [style.background-color]="hueSliderColor" [rgX]="1" [rgY]="1" [useCapture]="cpUseCapture" (newValue)="setSaturationAndBrightness($event)" class="saturation-lightness">
         <div [style.left.px]="slider.s" [style.top.px]="slider.v" class="cursor"></div>
     </div>
     <div class="box">
@@ -12,11 +12,11 @@
         <div class="right">
             <div *ngIf="cpAlphaChannel==='disabled'" style="height: 16px;"></div>
 
-            <div [slider] [rgX]="1" (newValue)="setHue($event)" class="hue" #hueSlider>
+            <div [slider] [rgX]="1" [useCapture]="cpUseCapture" (newValue)="setHue($event)" class="hue" #hueSlider>
                 <div [style.left.px]="slider.h" class="cursor"></div>
             </div>
 
-            <div [hidden]="cpAlphaChannel==='disabled'" [slider] [style.background-color]="alphaSliderColor" [rgX]="1" (newValue)="setAlpha($event)" class="alpha" #alphaSlider>
+            <div [hidden]="cpAlphaChannel==='disabled'" [slider] [style.background-color]="alphaSliderColor" [rgX]="1" [useCapture]="cpUseCapture" (newValue)="setAlpha($event)" class="alpha" #alphaSlider>
                 <div [style.left.px]="slider.a" class="cursor"></div>
             </div>
         </div>

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -29,6 +29,7 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
     public cpDialogDisplay: string;
     public cpSaveClickOutside: boolean;
     public cpAlphaChannel: string;
+    public cpUseCapture: boolean = false;
 
     public rgbaText: Rgba;
     public hslaText: Hsla;
@@ -71,7 +72,8 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
         cpCancelButton: boolean, cpCancelButtonClass: string, cpCancelButtonText: string,
         cpOKButton: boolean, cpOKButtonClass: string, cpOKButtonText: string,
         cpHeight: string, cpWidth: string,
-        cpIgnoredElements: any, cpDialogDisplay: string, cpSaveClickOutside: boolean, cpAlphaChannel: string, cpUseRootViewContainer: boolean) {
+        cpIgnoredElements: any, cpDialogDisplay: string, cpSaveClickOutside: boolean,
+        cpAlphaChannel: string, cpUseRootViewContainer: boolean, cpUseCapture: boolean) {
         this.directiveInstance = instance;
         this.initialColor = color;
         this.directiveElementRef = elementRef;
@@ -106,6 +108,7 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
         if (cpOutputFormat === 'hex' && cpAlphaChannel !== 'always' && cpAlphaChannel !== 'hex8') {
           this.cpAlphaChannel = 'disabled';
         }
+        this.cpUseCapture = cpUseCapture;
     }
 
     ngOnInit() {
@@ -208,7 +211,7 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
               this.cdr.detectChanges();
             }, 0);
             this.directiveInstance.toggle(true);
-            document.addEventListener('mousedown', this.listenerMouseDown, true);
+            document.addEventListener('mousedown', this.listenerMouseDown, this.cpUseCapture);
             window.addEventListener('resize', this.listenerResize);
         }
     }
@@ -217,7 +220,7 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
         if (this.show) {
             this.show = false;
             this.directiveInstance.toggle(false);
-            document.removeEventListener('mousedown', this.listenerMouseDown, true);
+            document.removeEventListener('mousedown', this.listenerMouseDown, this.cpUseCapture);
             window.removeEventListener('resize', this.listenerResize);
             this.cdr.detectChanges();
         }

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -208,7 +208,7 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
               this.cdr.detectChanges();
             }, 0);
             this.directiveInstance.toggle(true);
-            document.addEventListener('mousedown', this.listenerMouseDown);
+            document.addEventListener('mousedown', this.listenerMouseDown, true);
             window.addEventListener('resize', this.listenerResize);
         }
     }
@@ -217,7 +217,7 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
         if (this.show) {
             this.show = false;
             this.directiveInstance.toggle(false);
-            document.removeEventListener('mousedown', this.listenerMouseDown);
+            document.removeEventListener('mousedown', this.listenerMouseDown, true);
             window.removeEventListener('resize', this.listenerResize);
             this.cdr.detectChanges();
         }

--- a/src/lib/color-picker.directive.ts
+++ b/src/lib/color-picker.directive.ts
@@ -40,6 +40,7 @@ export class ColorPickerDirective implements OnInit, OnChanges {
     @Input('cpSaveClickOutside') cpSaveClickOutside: boolean = true;
     @Input('cpAlphaChannel') cpAlphaChannel: string = 'enabled';
     @Input('cpUseRootViewContainer') cpUseRootViewContainer: boolean = false;
+    @Input('cpUseCapture') cpUseCapture: boolean = false;
 
     private dialog: any;
     private created: boolean;
@@ -113,7 +114,8 @@ export class ColorPickerDirective implements OnInit, OnChanges {
                 this.cpPositionRelativeToArrow, this.cpOutputFormat, this.cpPresetLabel, this.cpPresetColors,
                 this.cpCancelButton, this.cpCancelButtonClass, this.cpCancelButtonText, this.cpOKButton,
                 this.cpOKButtonClass, this.cpOKButtonText, this.cpHeight, this.cpWidth, this.cpIgnoredElements,
-                this.cpDialogDisplay, this.cpSaveClickOutside, this.cpAlphaChannel, this.cpUseRootViewContainer);
+                this.cpDialogDisplay, this.cpSaveClickOutside, this.cpAlphaChannel, this.cpUseRootViewContainer,
+                this.cpUseCapture);
             this.dialog = cmpRef.instance;
 
             if (this.vcRef !== vcRef) {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, Output, EventEmitter, ElementRef, Renderer2 } from '@angular/core';
+import { Directive, Input, Output, EventEmitter, ElementRef } from '@angular/core';
 
 @Directive({
     selector: '[text]',
@@ -39,7 +39,7 @@ export class SliderDirective {
     private listenerMove: any;
     private listenerStop: any;
 
-    constructor(private el: ElementRef, private renderer: Renderer2) {
+    constructor(private el: ElementRef) {
         this.listenerMove = (event: any) => { this.move(event) };
         this.listenerStop = () => { this.stop() };
     }

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -1,4 +1,4 @@
-import { Directive, Input, Output, EventEmitter, ElementRef } from '@angular/core';
+import { Directive, Input, Output, EventEmitter, ElementRef, Renderer2 } from '@angular/core';
 
 @Directive({
     selector: '[text]',
@@ -35,10 +35,11 @@ export class SliderDirective {
     @Input('slider') slider: string;
     @Input('rgX') rgX: number;
     @Input('rgY') rgY: number;
+    @Input('useCapture') useCapture: boolean = false;
     private listenerMove: any;
     private listenerStop: any;
 
-    constructor(private el: ElementRef) {
+    constructor(private el: ElementRef, private renderer: Renderer2) {
         this.listenerMove = (event: any) => { this.move(event) };
         this.listenerStop = () => { this.stop() };
     }
@@ -65,17 +66,17 @@ export class SliderDirective {
 
     start(event: any) {
         this.setCursor(event);
-        document.addEventListener('mousemove', this.listenerMove, true);
-        document.addEventListener('touchmove', this.listenerMove, true);
-        document.addEventListener('mouseup', this.listenerStop, true);
-        document.addEventListener('touchend', this.listenerStop, true);
+        document.addEventListener('mousemove', this.listenerMove, this.useCapture);
+        document.addEventListener('touchmove', this.listenerMove, this.useCapture);
+        document.addEventListener('mouseup', this.listenerStop, this.useCapture);
+        document.addEventListener('touchend', this.listenerStop, this.useCapture);
     }
 
     stop() {
-        document.removeEventListener('mousemove', this.listenerMove, true);
-        document.removeEventListener('touchmove', this.listenerMove, true);
-        document.removeEventListener('mouseup', this.listenerStop, true);
-        document.removeEventListener('touchend', this.listenerStop, true);
+        document.removeEventListener('mousemove', this.listenerMove, this.useCapture);
+        document.removeEventListener('touchmove', this.listenerMove, this.useCapture);
+        document.removeEventListener('mouseup', this.listenerStop, this.useCapture);
+        document.removeEventListener('touchend', this.listenerStop, this.useCapture);
     }
 
     getX(event: any): number {

--- a/src/lib/helpers.ts
+++ b/src/lib/helpers.ts
@@ -65,17 +65,17 @@ export class SliderDirective {
 
     start(event: any) {
         this.setCursor(event);
-        document.addEventListener('mousemove', this.listenerMove);
-        document.addEventListener('touchmove', this.listenerMove);
-        document.addEventListener('mouseup', this.listenerStop);
-        document.addEventListener('touchend', this.listenerStop);
+        document.addEventListener('mousemove', this.listenerMove, true);
+        document.addEventListener('touchmove', this.listenerMove, true);
+        document.addEventListener('mouseup', this.listenerStop, true);
+        document.addEventListener('touchend', this.listenerStop, true);
     }
 
     stop() {
-        document.removeEventListener('mousemove', this.listenerMove);
-        document.removeEventListener('touchmove', this.listenerMove);
-        document.removeEventListener('mouseup', this.listenerStop);
-        document.removeEventListener('touchend', this.listenerStop);
+        document.removeEventListener('mousemove', this.listenerMove, true);
+        document.removeEventListener('touchmove', this.listenerMove, true);
+        document.removeEventListener('mouseup', this.listenerStop, true);
+        document.removeEventListener('touchend', this.listenerStop, true);
     }
 
     getX(event: any): number {


### PR DESCRIPTION
Fix issue with mousedown and mouseup events not firing when color picker component is injected into dynamically created DOM container element with external JS library. Setting a mouse event registrations with useCapture flag to true solves this issue.