### PR TITLE
Fix hex6 color read bug

### DIFF
--- a/src/lib/color-picker.service.ts
+++ b/src/lib/color-picker.service.ts
@@ -113,12 +113,12 @@ export class ColorPickerService {
         ];
         if (allowHex8) {
             stringParsers.push({
-                re: /#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})$/,
+                re: /#([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})([a-fA-F0-9]{2})?$/,
                 parse: function(execResult: any) {
                     return new Rgba(parseInt(execResult[1], 16) / 255,
                         parseInt(execResult[2], 16) / 255,
                         parseInt(execResult[3], 16) / 255,
-                        parseInt(execResult[4], 16) / 255);
+                        parseInt(execResult[4] || 'FF', 16) / 255);
                 }
             });
         } else {


### PR DESCRIPTION
Caused by who knows which PR, bug prevents reading hex6 color when alpha channel is enabled. This small change fixes it.