### PR TITLE
Add cpCancel event

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,4 +107,5 @@ import { ColorPickerModule } from 'ngx-color-picker';
                              //   ({input: string, value: string})
 (cpSliderChange)             // Slider name and its value, send when user changes color through slider
                              //   ({slider: string, value: Object})
+(cpCancel)                   // User cancelled, sent when the cancel button is pressed (void).
 ```

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -158,6 +158,8 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
             this.directiveInstance.colorChanged(this.initialColor, true);
             this.closeColorPicker();
         }
+
+        this.directiveInstance.cancelled();
     }
 
     oKColor() {

--- a/src/lib/color-picker.directive.ts
+++ b/src/lib/color-picker.directive.ts
@@ -20,6 +20,7 @@ export class ColorPickerDirective implements OnInit, OnChanges {
     @Output('cpInputChange') cpInputChange = new EventEmitter<any>(true);
     @Output('cpSliderChange') cpSliderChange = new EventEmitter<any>(true);
     @Output('cpToggleChange') cpToggleChange = new EventEmitter<boolean>(true);
+    @Output('cpCancel') cpCancel = new EventEmitter<void>();
     @Input('cpPosition') cpPosition: string = 'right';
     @Input('cpPositionOffset') cpPositionOffset: string = '0%';
     @Input('cpPositionRelativeToArrow') cpPositionRelativeToArrow: boolean = false;
@@ -147,5 +148,9 @@ export class ColorPickerDirective implements OnInit, OnChanges {
 
     toggle(value: boolean) {
         this.cpToggleChange.emit(value);
+    }
+
+    cancelled() {
+        this.cpCancel.emit();
     }
 }


### PR DESCRIPTION
Add a `(cpCancel)` event that component users can hook into to perform some action when the user clicks "cancel". This is necessary to integrate inline pickers into e.g. modal dialogs, or grid cell editors.

Fixes #42 