### PR TITLE
Fix dialog positioning on non-fixed parents (bootstrap)

### DIFF
--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -293,7 +293,7 @@ export class ColorPickerComponent implements OnInit, AfterViewInit {
         let boxDirective = this.createBox(this.directiveElementRef.nativeElement, (position !== 'fixed'));
         if ((position !== 'fixed' || parentNode) && !this.useRootViewContainer) {
             if (parentNode === null) { parentNode = node }
-            let boxParent = this.createBox(parentNode, true);
+            let boxParent = this.createBox(parentNode, (position !== 'fixed'));
             this.top = boxDirective.top - boxParent.top;
             this.left = boxDirective.left - boxParent.left;
         } else {


### PR DESCRIPTION
Color picker on a Bootstrap modal (these have `transform` set) opened on a _scrolled down_ page has inconsistent positioning. `boxDirective` is calculated with window scroll ignored (`position !== 'fixed'`, line 293) while `boxParent` accounts for scroll unconditionally (`true`, line 296) resulting in negative `top` value. Both boxes should account for parent's position.