### PR TITLE
Use the 'h' value from the slider, not from the computed color

### DIFF
--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -30,6 +30,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private directiveInstance: any;
 
+  private sliderH: number;
   private sliderDimMax: SliderDimension;
   private directiveElementRef: ElementRef;
 
@@ -336,6 +337,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
   public onHueChange(value: {v: number, rgX: number}) {
     this.hsva.h = value.v / value.rgX;
+    this.sliderH = this.hsva.h;
 
     this.updateColorPicker();
 
@@ -556,7 +558,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
       this.selectedColor = this.service.outputFormat(this.hsva, 'rgba', null);
 
       this.slider = new SliderPosition(
-        (this.hsva.h) * this.sliderDimMax.h - 8,
+        (this.sliderH || this.hsva.h) * this.sliderDimMax.h - 8,
         this.hsva.s * this.sliderDimMax.s - 8,
         (1 - this.hsva.v) * this.sliderDimMax.v - 8,
         this.hsva.a * this.sliderDimMax.a - 8


### PR DESCRIPTION
In my project I'm encountering a bug where the hue slider immediately jumps back to the leftmost position when you move it anywhere else if the color that is currently being selected sits on the grayscale (#ffffff, #ececec, etc). I think this is because the slider computes the color value and determines that there is no hue and thus the hue slider should sit all of the way to the left. The problem is, if the user wants to pick a color in the blue, they should be able to slide the hue over and then use the main color picker area, but the hue slider immediately jumps back after they finish sliding it over.

My recommendation via this PR is to save the current hue slider position on a hue change and reuse that when updating the slider position as long as it is available. This should make the hue slider stay where the user drags it until the color picker component destructs and reconstructs with a new color value, at which point it can recalculate the hue from the color and move the slider to the far left again.