### PR TITLE
Use sliderH when determining the hue on updateColorPicker

### DIFF
--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -538,7 +538,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
       const hsla = this.service.hsva2hsla(this.hsva);
       const rgba = this.service.denormalizeRGBA(this.service.hsvaToRgba(this.hsva));
 
-      const hue = this.service.denormalizeRGBA(this.service.hsvaToRgba(new Hsva(this.hsva.h, 1, 1, 1)));
+      const hue = this.service.denormalizeRGBA(this.service.hsvaToRgba(new Hsva(this.sliderH || this.hsva.h, 1, 1, 1)));
 
       if (update) {
         this.hslaText = new Hsla(Math.round((hsla.h) * 360), Math.round(hsla.s * 100), Math.round(hsla.l * 100),


### PR DESCRIPTION
A follow-up to https://github.com/zefoy/ngx-color-picker/pull/100. Saving the 'h' value from the onHueChange event fixed the cursor positioning on the hue slider, but now the saturation 'slider' flashes back to all red when you move the hue slider for a color on the gray scale. This seems to be fixable via the same method, you just have to reuse the saved sliderH value when calculating the hue as well as the slider position.