### PR TITLE
Fix ExpressionChangedAfterItHasBeenCheckedError when we use cpUseRoot…

### DIFF
--- a/src/lib/color-picker.directive.ts
+++ b/src/lib/color-picker.directive.ts
@@ -120,6 +120,10 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
         }
 
         this.dialog.setColorFromString(changes.colorPicker.currentValue, false);
+        
+        if (this.cpUseRootViewContainer && this.cpDialogDisplay != 'inline') {
+          this.cmpRef.changeDetectorRef.detectChanges();
+        }
       }
 
       this.ignoreChanges = false;


### PR DESCRIPTION
…ViewContainer
This fix an issue with [cpUseRootViewContainer]="true" mentioned by @marcj: https://github.com/zefoy/ngx-color-picker/issues/29#issuecomment-370170179