### PR TITLE
Fix dialog positioning if parent node not detected

### DIFF
--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -652,7 +652,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
       const boxDirective = this.createDialogBox(this.directiveElementRef.nativeElement, (position !== 'fixed'));
 
-      if (this.useRootViewContainer || (position === 'fixed' && !parentNode)) {
+      if (this.useRootViewContainer || (position === 'fixed' && (!parentNode || parentNode instanceof HTMLUnknownElement))) {
         this.top = boxDirective.top;
         this.left = boxDirective.left;
       } else {


### PR DESCRIPTION
Issue on IE11 and angular material if the color picker is positioned inside a dialog next to a text input

Note: I really don't understand the while loop above and the parent detection, so this is more of a quickfix :) But at least it shouldn't break existing functionality. This fix is specific for IE11 but Chrome and Firefox do play along fine too.