### PR TITLE
Keeps alpha for Hex input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea/
 dist/
 bundles/
 

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ import { ColorPickerModule } from 'ngx-color-picker';
 [cpPresetLabel]              // Label text for the preset colors if any provided ('Preset colors').
 [cpPresetColors]             // Array of preset colors to show in the color picker dialog ([]).
 
-[cpDefaultInput]             // Initial color input field shown: 'hex', 'rgba', 'hsla' ('hex').
+[cpDefaultInput]             // Initial color input field shown: 'auto', 'hex', 'rgba', 'hsla' ('auto').
 [cpDisableInput]             // Disables / hides the color input field from the dialog (false).
 
 [cpDialogDisplay]            // Dialog positioning mode: 'popup', 'inline' ('popup').

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import { ColorPickerModule } from 'ngx-color-picker';
 [cpDisabled]                 // Disables opening of the color picker dialog via toggle / events.
 
 [cpOutputFormat]             // Output color format: 'auto', 'hex', 'rgba', 'hsla' ('auto').
-[cpAlphaChannel]             // Alpha in output value: 'enabled', 'disabled', 'always' ('enabled').
+[cpAlphaChannel]             // Alpha in output value: 'enabled', 'disabled', 'always', 'forced', 'hex8' ('enabled').
 [cpFallbackColor]            // Is used when the color is not well-formed or is undefined ('#000').
 
 [cpPosition]                 // Dialog position: 'right', 'left', 'top', 'bottom' ('right').
@@ -81,6 +81,7 @@ import { ColorPickerModule } from 'ngx-color-picker';
 [cpPresetLabel]              // Label text for the preset colors if any provided ('Preset colors').
 [cpPresetColors]             // Array of preset colors to show in the color picker dialog ([]).
 
+[cpDefaultInput]             // Initial color input field shown: 'hex', 'rgba', 'hsla' ('hex').
 [cpDisableInput]             // Disables / hides the color input field from the dialog (false).
 
 [cpDialogDisplay]            // Dialog positioning mode: 'popup', 'inline' ('popup').

--- a/README.md
+++ b/README.md
@@ -81,7 +81,6 @@ import { ColorPickerModule } from 'ngx-color-picker';
 [cpPresetLabel]              // Label text for the preset colors if any provided ('Preset colors').
 [cpPresetColors]             // Array of preset colors to show in the color picker dialog ([]).
 
-[cpDefaultInput]             // Initial color input field shown: 'auto', 'hex', 'rgba', 'hsla' ('auto').
 [cpDisableInput]             // Disables / hides the color input field from the dialog (false).
 
 [cpDialogDisplay]            // Dialog positioning mode: 'popup', 'inline' ('popup').

--- a/README.md
+++ b/README.md
@@ -71,7 +71,7 @@ import { ColorPickerModule } from 'ngx-color-picker';
 [cpDisabled]                 // Disables opening of the color picker dialog via toggle / events.
 
 [cpOutputFormat]             // Output color format: 'auto', 'hex', 'rgba', 'hsla' ('auto').
-[cpAlphaChannel]             // Alpha in output value: 'enabled', 'disabled', 'always', 'forced', 'hex8' ('enabled').
+[cpAlphaChannel]             // Alpha in output value: 'enabled', 'disabled', 'always', 'forced' ('enabled').
 [cpFallbackColor]            // Is used when the color is not well-formed or is undefined ('#000').
 
 [cpPosition]                 // Dialog position: 'right', 'left', 'top', 'bottom' ('right').

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -516,7 +516,7 @@
             <td>cpDefaultInput</td>
             <td>
               <b>'hex'</b>, 'rgba', 'hsla'<br>
-              hex: initial color input field is set to hex6/hex8.<br>
+              hex: initial color input field is set to hex.<br>
               rgba: initial color input field is set to rgba.<br>
               hsla: initial color input field is set to hsla.<br>
             </td>
@@ -533,10 +533,9 @@
           <tr>
             <td>cpAlphaChannel</td>
             <td>
-              <b>'enabled'</b>, 'disabled', 'always', 'forced', 'hex8'<br>
+              <b>'enabled'</b>, 'disabled', 'always', 'forced'<br>
               enabled: alpha channel is not included for hexadecimal (hex6) values or for values without alpha (alpha = 1).<br>
               always: alpha channel is included for hexadecimal (hex6) values and values without alpha (alpha = 1).<br>
-              hex8: alpha channel is included in hexadecimal (hex8) values.<br>
               forced: alpha channel field is added for hexadecimal (hex6) values (alpha = 1).<br>
               disabled: alpha channel is completely disabled.<br>
             </td>

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -536,7 +536,7 @@
               <b>'enabled'</b>, 'disabled', 'always', 'forced'<br>
               enabled: alpha channel is not included for hexadecimal (hex6) values or for values without alpha (alpha = 1).<br>
               always: alpha channel is included for hexadecimal (hex6) values and values without alpha (alpha = 1).<br>
-              forced: alpha channel field is added for hexadecimal (hex6) values (alpha = 1).<br>
+              forced: alpha channel field is added for hexadecimal (hex6) values.<br>
               disabled: alpha channel is completely disabled.<br>
             </td>
           </tr>

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -248,7 +248,7 @@
 
   <div class="row">
     <div class="col-md-5">
-      <input [value]="color13" [style.background]="color13" [cpOutputFormat]="'rgba'" [cpAlphaChannel]="'disabled'" [(colorPicker)]="color13"/>
+      <input [value]="color13" [style.background]="color13" [cpAlphaChannel]="'disabled'" [cpOutputFormat]="'rgba'" [(colorPicker)]="color13"/>
 
       <br>
 
@@ -256,30 +256,41 @@
 
       <br>
 
-      <input [value]="color15" [style.background]="rgbaText" [cpAlphaChannel]="'always'" [cpOutputFormat]="'hex'" [colorPicker]="color15" (colorPickerChange)="rgbaText=onChangeColorHex8($event);color15=$event"/>
+      <input [value]="color15" [style.background]="color15" [cpAlphaChannel]="'forced'" [cpDefaultInput]="'hex'" [cpOutputFormat]="'rgba'" [(colorPicker)]="color15"/>
+
+      <br>
+
+      <input [value]="color16" [style.background]="rgbaText" [cpAlphaChannel]="'always'" [cpOutputFormat]="'hex'" [colorPicker]="color16" (colorPickerChange)="rgbaText=onChangeColorHex8($event);color16=$event"/>
     </div>
 
     <div class="col-md-7">
       <p>Change alpha channel behaviour:</p>
       <pre>
-&lt;input [value]="color"
-       [style.background]="color"
+&lt;input [value]="color13"
+       [style.background]="color13"
        [cpAlphaChannel]="'disabled'"
        [cpOutputFormat]="'rgba'"
-       [(colorPicker)]="color5"/&gt;
+       [(colorPicker)]="color13"/&gt;
 
-&lt;input [value]="color"
-       [style.background]="color"
+&lt;input [value]="color14"
+       [style.background]="color14"
        [cpAlphaChannel]="'always'"
        [cpOutputFormat]="'rgba'"
-       [(colorPicker)]="color4"/&gt;
+       [(colorPicker)]="color14"/&gt;
 
-&lt;input [value]="color"
+&lt;input [value]="color15"
+       [style.background]="color15"
+       [cpAlphaChannel]="'forced'"
+       [cpDefaultInput]="'hex'"
+       [cpOutputFormat]="'rgba'"
+       [(colorPicker)]="color15"/&gt;
+
+&lt;input [value]="color16"
        [style.background]="rgbaText"
        [cpAlphaChannel]="'always'"
        [cpOutputFormat]="'hex'"
-       [colorPicker]="color"
-       (colorPickerChange)="rgbaText=onChangeColorHex8($event);color=$event"/&gt;
+       [colorPicker]="color16"
+       (colorPickerChange)="rgbaText=onChangeColorHex8($event);color16=$event"/&gt;
       </pre>
     </div>
   </div>
@@ -325,18 +336,18 @@
 
   <div class="row">
     <div class="col-md-5">
-      <input [style.background]="color16" [cpAlphaChannel]="'always'" [cpOutputFormat]="'rgba'" [cpPresetColors]="['#fff', '#2889e9']" [cpAddColorButton]="true" [(colorPicker)]="color16"/>
+      <input [style.background]="color17" [cpAlphaChannel]="'always'" [cpOutputFormat]="'rgba'" [cpPresetColors]="['#fff', '#2889e9']" [cpAddColorButton]="true" [(colorPicker)]="color17"/>
     </div>
 
     <div class="col-md-7">
       <p>Add and remove preset colors:</p>
       <pre>
-&lt;input [style.background]="color"
+&lt;input [style.background]="color17"
        [cpAlphaChannel]="'always'"
        [cpOutputFormat]="'rgba'"
        [cpPresetColors]="['#fff', '#2889e9']"
        [cpAddColorButton]="true"
-       [(colorPicker)]="color"/&gt;
+       [(colorPicker)]="color17"/&gt;
       </pre>
     </div>
   </div>
@@ -502,11 +513,31 @@
           </tr>
 
           <tr>
+            <td>cpDefaultInput</td>
+            <td>
+              <b>'hex'</b>, 'rgba', 'hsla'<br>
+              hex: initial color input field is set to hex6/hex8.<br>
+              rgba: initial color input field is set to rgba.<br>
+              hsla: initial color input field is set to hsla.<br>
+            </td>
+          </tr>
+
+          <tr>
+            <td>cpDisableInput</td>
+            <td>
+              <b>false</b>, true<br>
+              Disables / hides the color input field from the dialog.<br>
+            </td>
+          </tr>
+
+          <tr>
             <td>cpAlphaChannel</td>
             <td>
-              <b>'enabled'</b>, 'disabled', 'always'<br>
-              enabled: alpha channel is not included for hexadecimal values or for values without alpha (alpha = 1).<br>
-              always: alpha channel is included for hexadecimal values and values without alpha (alpha = 1).<br>
+              <b>'enabled'</b>, 'disabled', 'always', 'forced', 'hex8'<br>
+              enabled: alpha channel is not included for hexadecimal (hex6) values or for values without alpha (alpha = 1).<br>
+              always: alpha channel is included for hexadecimal (hex6) values and values without alpha (alpha = 1).<br>
+              hex8: alpha channel is included in hexadecimal (hex8) values.<br>
+              forced: alpha channel field is added for hexadecimal (hex6) values (alpha = 1).<br>
               disabled: alpha channel is completely disabled.<br>
             </td>
           </tr>

--- a/example/src/app/app.component.html
+++ b/example/src/app/app.component.html
@@ -256,7 +256,7 @@
 
       <br>
 
-      <input [value]="color15" [style.background]="color15" [cpAlphaChannel]="'forced'" [cpDefaultInput]="'hex'" [cpOutputFormat]="'rgba'" [(colorPicker)]="color15"/>
+      <input [value]="color15" [style.background]="color15" [cpAlphaChannel]="'forced'" [cpOutputFormat]="'hex'" [(colorPicker)]="color15"/>
 
       <br>
 
@@ -281,8 +281,7 @@
 &lt;input [value]="color15"
        [style.background]="color15"
        [cpAlphaChannel]="'forced'"
-       [cpDefaultInput]="'hex'"
-       [cpOutputFormat]="'rgba'"
+       [cpOutputFormat]="'hex'"
        [(colorPicker)]="color15"/&gt;
 
 &lt;input [value]="color16"
@@ -509,16 +508,6 @@
               <b>'popup'</b>, 'inline'<br>
               popup: dialog is showed when user clicks in the directive.<br>
               inline: dialog is showed permanently. You can show/hide the dialog with cpToggle.<br>
-            </td>
-          </tr>
-
-          <tr>
-            <td>cpDefaultInput</td>
-            <td>
-              <b>'hex'</b>, 'rgba', 'hsla'<br>
-              hex: initial color input field is set to hex.<br>
-              rgba: initial color input field is set to rgba.<br>
-              hsla: initial color input field is set to hsla.<br>
             </td>
           </tr>
 

--- a/example/src/app/app.component.ts
+++ b/example/src/app/app.component.ts
@@ -37,8 +37,9 @@ export class AppComponent {
   public color12: string = '#f200bd';
   public color13: string = 'rgba(0, 255, 0, 0.5)';
   public color14: string = 'rgb(0, 255, 255)';
-  public color15: string = '#a51ad633';
-  public color16: string = 'rgba(45,208,45,0.5)';
+  public color15: string = 'rgb(255, 0, 0)';
+  public color16: string = '#a51ad633';
+  public color17: string = 'rgba(45,208,45,0.5)';
 
   public cmykColor: Cmyk = new Cmyk(0, 0, 0, 0);
 

--- a/src/lib/color-picker.component.css
+++ b/src/lib/color-picker.component.css
@@ -197,6 +197,12 @@
   border: #a9a9a9 solid 1px;
 }
 
+.color-picker .hex-text--with-alpha .box div:first-child,
+.color-picker .hex-text--with-alpha .box input:first-child {
+  flex-grow: 3;
+  margin-right: 8px;
+}
+
 .color-picker .hsla-text,
 .color-picker .rgba-text {
   width: 100%;

--- a/src/lib/color-picker.component.html
+++ b/src/lib/color-picker.component.html
@@ -55,13 +55,14 @@
     </div>
   </div>
 
-  <div *ngIf="!cpDisableInput" class="hex-text" [style.display]="format !== 0 ? 'none' : 'block'">
+  <div *ngIf="!cpDisableInput" class="hex-text" [class.hex-text--with-alpha]="cpAlphaChannel==='forced'" [style.display]="format !== 0 ? 'none' : 'block'">
     <div class="box">
       <input [text] [value]="hexText" (blur)="onHexInput(null)" (keyup.enter)="onAcceptColor($event)" (newValue)="onHexInput($event)"/>
+      <input *ngIf="cpAlphaChannel==='forced'" type="number" pattern="[0-9]+([\.,][0-9]{1,2})?" min="0" max="1" step="0.1" [text] [rg]="1" [value]="hexAlpha" (keyup.enter)="onAcceptColor($event)" (newValue)="onAlphaInput($event)"/>
     </div>
 
     <div class="box">
-      <div>Hex</div>
+      <div>Hex</div><div *ngIf="cpAlphaChannel==='forced'">A</div>
     </div>
   </div>
 

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -13,7 +13,7 @@ import {
 import { detectIE, SliderDimension, SliderPosition } from './helpers';
 
 import { Formats, Hsla, Hsva, Rgba } from './formats';
-import { AlphaChannel, DefaultInput } from './types';
+import { AlphaChannel } from './types';
 
 import { ColorPickerService } from './color-picker.service';
 
@@ -77,7 +77,6 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   public cpAlphaChannel: AlphaChannel;
   public cpOutputFormat: string;
 
-  public cpDefaultInput: DefaultInput;
   public cpDisableInput: boolean;
   public cpDialogDisplay: string;
 
@@ -133,10 +132,9 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
     this.sliderDimMax = new SliderDimension(hueWidth, this.cpWidth, 130, alphaWidth);
 
-    const inputFormat = this.cpDefaultInput === 'auto' ? this.cpOutputFormat : this.cpDefaultInput;
-    if (inputFormat === 'rgba') {
+    if (this.cpOutputFormat === 'rgba') {
       this.format = Formats.RGBA;
-    } else if (inputFormat === 'hsla') {
+    } else if (this.cpOutputFormat === 'hsla') {
       this.format = Formats.HSLA;
     } else {
       this.format = Formats.HEX;
@@ -193,7 +191,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
   public setupDialog(instance: any, elementRef: ElementRef, color: any,
     cpWidth: string, cpHeight: string, cpDialogDisplay: string, cpFallbackColor: string,
-    cpAlphaChannel: AlphaChannel, cpOutputFormat: string, cpDisableInput: boolean, cpDefaultInput: DefaultInput,
+    cpAlphaChannel: AlphaChannel, cpOutputFormat: string, cpDisableInput: boolean,
     cpIgnoredElements: any, cpSaveClickOutside: boolean, cpUseRootViewContainer: boolean,
     cpPosition: string, cpPositionOffset: string, cpPositionRelativeToArrow: boolean,
     cpPresetLabel: string, cpPresetColors: string[], cpMaxPresetColorsLength: number,
@@ -210,7 +208,6 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.directiveInstance = instance;
     this.directiveElementRef = elementRef;
 
-    this.cpDefaultInput = cpDefaultInput;
     this.cpDisableInput = cpDisableInput;
 
     this.cpAlphaChannel = cpAlphaChannel;
@@ -258,7 +255,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
       this.dialogArrowOffset = 0;
     }
 
-    if (cpOutputFormat === 'hex' && cpAlphaChannel !== 'always') {
+    if (cpOutputFormat === 'hex' && cpAlphaChannel !== 'always' && cpAlphaChannel !== 'forced') {
       this.cpAlphaChannel = 'disabled';
     }
   }

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -1,6 +1,14 @@
-import { Component, OnInit, OnDestroy, AfterViewInit,
-  ViewChild, HostListener, ViewEncapsulation,
-  ElementRef, ChangeDetectorRef } from '@angular/core';
+import {
+    AfterViewInit,
+    ChangeDetectorRef,
+    Component,
+    ElementRef,
+    HostListener,
+    OnDestroy,
+    OnInit,
+    ViewChild,
+    ViewEncapsulation
+} from '@angular/core';
 
 import { detectIE, SliderDimension, SliderPosition } from './helpers';
 
@@ -23,8 +31,6 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   private width: number;
   private height: number;
 
-  private formats: Formats[];
-
   private outputColor: string;
   private initialColor: string;
   private fallbackColor: string;
@@ -38,6 +44,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   private sliderDimMax: SliderDimension;
   private directiveElementRef: ElementRef;
 
+  private dialogInputFields: Formats[] = [Formats.HEX, Formats.RGBA, Formats.HSLA];
   private dialogArrowSize: number = 10;
   private dialogArrowOffset: number = 15;
 
@@ -218,10 +225,6 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.width = this.cpWidth = parseInt(cpWidth, 10);
     this.height = this.cpHeight = parseInt(cpHeight, 10);
 
-    this.formats = Object.keys(Formats)
-      .filter((format: any) => !isNaN(format))
-      .map(value => Number(value));
-
     this.cpPosition = cpPosition;
     this.cpPositionOffset = parseInt(cpPositionOffset, 10);
 
@@ -355,7 +358,8 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   public onFormatToggle(): void {
-    this.format = this.formats[(this.formats.indexOf(this.format) + 1) % this.formats.length];
+    const nextInput = (this.dialogInputFields.indexOf(this.format) + 1) % this.dialogInputFields.length;
+    this.format = this.dialogInputFields[nextInput];
   }
 
   public onColorChange(value: {s: number, v: number, rgX: number, rgY: number}): void {
@@ -422,7 +426,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
             .join('');
         }
         if (this.cpAlphaChannel === 'forced') {
-          value +=  Math.round(this.hsva.a * 255).toString(16);
+          value += Math.round(this.hsva.a * 255).toString(16);
         }
 
         this.setColorFromString(value, true, false);

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -2,10 +2,10 @@ import { Component, OnInit, OnDestroy, AfterViewInit,
   ViewChild, HostListener, ViewEncapsulation,
   ElementRef, ChangeDetectorRef } from '@angular/core';
 
-import { detectIE } from './helpers';
+import { detectIE, SliderDimension, SliderPosition } from './helpers';
 
-import { Rgba, Hsla, Hsva } from './formats';
-import { SliderPosition, SliderDimension } from './helpers';
+import { Formats, Hsla, Hsva, Rgba } from './formats';
+import { AlphaChannel, DefaultInput } from './types';
 
 import { ColorPickerService } from './color-picker.service';
 
@@ -22,6 +22,8 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
   private width: number;
   private height: number;
+
+  private formats: Formats[];
 
   private outputColor: string;
   private initialColor: string;
@@ -48,10 +50,11 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   public left: number;
   public position: string;
 
-  public format: number;
+  public format: Formats;
   public slider: SliderPosition;
 
   public hexText: string;
+  public hexAlpha: number;
   public hslaText: Hsla;
   public rgbaText: Rgba;
 
@@ -64,9 +67,10 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   public cpWidth: number;
   public cpHeight: number;
 
-  public cpAlphaChannel: string;
+  public cpAlphaChannel: AlphaChannel;
   public cpOutputFormat: string;
 
+  public cpDefaultInput: DefaultInput;
   public cpDisableInput: boolean;
   public cpDialogDisplay: string;
 
@@ -122,12 +126,13 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
     this.sliderDimMax = new SliderDimension(hueWidth, this.cpWidth, 130, alphaWidth);
 
-    if (this.cpOutputFormat === 'rgba') {
-      this.format = 1;
-    } else if (this.cpOutputFormat === 'hsla') {
-      this.format = 2;
+    const inputFormat = this.cpDefaultInput === 'auto' ? this.cpOutputFormat : this.cpDefaultInput;
+    if (inputFormat === 'rgba') {
+      this.format = Formats.RGBA;
+    } else if (inputFormat === 'hsla') {
+      this.format = Formats.HSLA;
     } else {
-      this.format = 0;
+      this.format = Formats.HEX;
     }
 
     if (this.cpOutputFormat === 'auto') {
@@ -181,7 +186,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
   public setupDialog(instance: any, elementRef: ElementRef, color: any,
     cpWidth: string, cpHeight: string, cpDialogDisplay: string, cpFallbackColor: string,
-    cpAlphaChannel: string, cpOutputFormat: string, cpDisableInput: boolean,
+    cpAlphaChannel: AlphaChannel, cpOutputFormat: string, cpDisableInput: boolean, cpDefaultInput: DefaultInput,
     cpIgnoredElements: any, cpSaveClickOutside: boolean, cpUseRootViewContainer: boolean,
     cpPosition: string, cpPositionOffset: string, cpPositionRelativeToArrow: boolean,
     cpPresetLabel: string, cpPresetColors: string[], cpMaxPresetColorsLength: number,
@@ -198,6 +203,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.directiveInstance = instance;
     this.directiveElementRef = elementRef;
 
+    this.cpDefaultInput = cpDefaultInput;
     this.cpDisableInput = cpDisableInput;
 
     this.cpAlphaChannel = cpAlphaChannel;
@@ -211,6 +217,10 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
 
     this.width = this.cpWidth = parseInt(cpWidth, 10);
     this.height = this.cpHeight = parseInt(cpHeight, 10);
+
+    this.formats = Object.keys(Formats)
+      .filter((format: any) => !isNaN(format))
+      .map(value => Number(value));
 
     this.cpPosition = cpPosition;
     this.cpPositionOffset = parseInt(cpPositionOffset, 10);
@@ -262,7 +272,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   public setColorFromString(value: string, emit: boolean = true, update: boolean = true): void {
     let hsva: Hsva | null;
 
-    if (this.cpAlphaChannel === 'always') {
+    if (this.cpAlphaChannel === 'always' || this.cpAlphaChannel === 'forced') {
       hsva = this.service.stringToHsva(value, true);
 
       if (!hsva && !this.hsva) {
@@ -345,7 +355,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   }
 
   public onFormatToggle(): void {
-    this.format = (this.format + 1) % 3;
+    this.format = this.formats[(this.formats.indexOf(this.format) + 1) % this.formats.length];
   }
 
   public onColorChange(value: {s: number, v: number, rgX: number, rgY: number}): void {
@@ -400,13 +410,29 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
         value = '#' + value;
       }
 
-      this.setColorFromString(value, true, false);
+      let validHex = /^#([a-f0-9]{3}|[a-f0-9]{6})$/gi;
+      if (this.cpAlphaChannel === 'always') {
+        validHex = /^#([a-f0-9]{3}|[a-f0-9]{6}|[a-f0-9]{8})$/gi;
+      }
+      if (validHex.test(value)) {
+        if (value.length < 5) {
+          value = '#' + value.substring(1)
+            .split('')
+            .map(c => c + c)
+            .join('');
+        }
+        if (this.cpAlphaChannel === 'forced') {
+          value +=  Math.round(this.hsva.a * 255).toString(16);
+        }
 
-      this.directiveInstance.inputChanged({
-        input: 'hex',
-        value: value,
-        color: this.outputColor
-      });
+        this.setColorFromString(value, true, false);
+
+        this.directiveInstance.inputChanged({
+          input: 'hex',
+          value: value,
+          color: this.outputColor
+        });
+      }
     }
   }
 
@@ -597,6 +623,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
         const allowHex8 = this.cpAlphaChannel === 'always';
 
         this.hexText = this.service.rgbaToHex(rgba, allowHex8);
+        this.hexAlpha = this.rgbaText.a;
       }
 
       this.hueSliderColor = 'rgb(' + hue.r + ',' + hue.g + ',' + hue.b + ')';

--- a/src/lib/color-picker.directive.ts
+++ b/src/lib/color-picker.directive.ts
@@ -4,6 +4,7 @@ import { Directive, OnChanges, OnDestroy, Input, Output, EventEmitter,
 
 import { ColorPickerService } from './color-picker.service';
 import { ColorPickerComponent } from './color-picker.component';
+import { AlphaChannel, DefaultInput } from './types';
 
 @Directive({
   selector: '[colorPicker]',
@@ -27,10 +28,11 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
 
   @Input() cpIgnoredElements: any = [];
 
+  @Input() cpDefaultInput: DefaultInput = 'auto';
   @Input() cpDisableInput: boolean = false;
 
   @Input() cpOutputFormat: string = 'auto';
-  @Input() cpAlphaChannel: string = 'enabled';
+  @Input() cpAlphaChannel: AlphaChannel = 'enabled';
 
   @Input() cpFallbackColor: string = '#fff';
 
@@ -162,7 +164,7 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
 
       this.cmpRef.instance.setupDialog(this, this.elRef, this.colorPicker,
         this.cpWidth, this.cpHeight, this.cpDialogDisplay, this.cpFallbackColor,
-        this.cpAlphaChannel, this.cpOutputFormat, this.cpDisableInput,
+        this.cpAlphaChannel, this.cpOutputFormat, this.cpDisableInput, this.cpDefaultInput,
         this.cpIgnoredElements, this.cpSaveClickOutside, this.cpUseRootViewContainer,
         this.cpPosition, this.cpPositionOffset, this.cpPositionRelativeToArrow,
         this.cpPresetLabel, this.cpPresetColors, this.cpMaxPresetColorsLength,

--- a/src/lib/color-picker.directive.ts
+++ b/src/lib/color-picker.directive.ts
@@ -4,7 +4,7 @@ import { Directive, OnChanges, OnDestroy, Input, Output, EventEmitter,
 
 import { ColorPickerService } from './color-picker.service';
 import { ColorPickerComponent } from './color-picker.component';
-import { AlphaChannel, DefaultInput } from './types';
+import { AlphaChannel } from './types';
 
 @Directive({
   selector: '[colorPicker]',
@@ -28,7 +28,6 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
 
   @Input() cpIgnoredElements: any = [];
 
-  @Input() cpDefaultInput: DefaultInput = 'auto';
   @Input() cpDisableInput: boolean = false;
 
   @Input() cpOutputFormat: string = 'auto';
@@ -164,7 +163,7 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
 
       this.cmpRef.instance.setupDialog(this, this.elRef, this.colorPicker,
         this.cpWidth, this.cpHeight, this.cpDialogDisplay, this.cpFallbackColor,
-        this.cpAlphaChannel, this.cpOutputFormat, this.cpDisableInput, this.cpDefaultInput,
+        this.cpAlphaChannel, this.cpOutputFormat, this.cpDisableInput,
         this.cpIgnoredElements, this.cpSaveClickOutside, this.cpUseRootViewContainer,
         this.cpPosition, this.cpPositionOffset, this.cpPositionRelativeToArrow,
         this.cpPresetLabel, this.cpPresetColors, this.cpMaxPresetColorsLength,

--- a/src/lib/color-picker.service.ts
+++ b/src/lib/color-picker.service.ts
@@ -251,7 +251,7 @@ export class ColorPickerService {
         }
 
       default:
-        const allowHex8 = (alphaChannel === 'always' || alphaChannel === 'hex8');
+        const allowHex8 = (alphaChannel === 'always' || alphaChannel === 'forced' || alphaChannel === 'hex8');
 
         return this.rgbaToHex(this.denormalizeRGBA(this.hsvaToRgba(hsva)), allowHex8);
     }

--- a/src/lib/formats.ts
+++ b/src/lib/formats.ts
@@ -13,3 +13,9 @@ export class Hsva {
 export class Rgba {
   constructor(public r: number, public g: number, public b: number, public a: number) {}
 }
+
+export enum Formats {
+  HEX,
+  RGBA,
+  HSLA
+}

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,0 +1,3 @@
+export type AlphaChannel = 'enabled' | 'disabled' | 'always' | 'forced' | 'hex8';
+
+export type DefaultInput = 'auto' | 'hex' | 'rgba' | 'hsla';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,3 @@
-export type AlphaChannel = 'enabled' | 'disabled' | 'always' | 'forced' | 'hex8';
+export type AlphaChannel = 'enabled' | 'disabled' | 'always' | 'forced';
 
 export type DefaultInput = 'auto' | 'hex' | 'rgba' | 'hsla';

--- a/src/lib/types.ts
+++ b/src/lib/types.ts
@@ -1,3 +1,1 @@
 export type AlphaChannel = 'enabled' | 'disabled' | 'always' | 'forced';
-
-export type DefaultInput = 'auto' | 'hex' | 'rgba' | 'hsla';


### PR DESCRIPTION
- Adds `'force'` value for the `cpAlphaChannel` parameter, so that the alpha input field can be used along with the hex6 input field;
- ~Adds the `cpDefaultInput` parameter (`'auto'|'hex'|'rgba'|'hsla'`) for specifying which input field to show initially. The default `'auto'` behaves like the current implementation (the input field is chosen based on `cpOutputFormat`);~
- Adds validation for the Hex input field: only hex3/6/8 values are used to update the picker.