### PR TITLE
[cpAddColorButton] button attribute to type="button" to stop form submissions

### DIFF
--- a/src/lib/color-picker.component.html
+++ b/src/lib/color-picker.component.html
@@ -11,7 +11,7 @@
 
       <div class="selected-color" [style.background-color]="selectedColor"></div>
 
-      <button *ngIf="cpAddColorButton" class="{{cpAddColorButtonClass}}" [disabled]="cpPresetColors && cpPresetColors.length >= cpMaxPresetColorsLength" (click)="onAddPresetColor($event, selectedColor)">
+      <button *ngIf="cpAddColorButton" type="button" class="{{cpAddColorButtonClass}}" [disabled]="cpPresetColors && cpPresetColors.length >= cpMaxPresetColorsLength" (click)="onAddPresetColor($event, selectedColor)">
         {{cpAddColorButtonText}}
       </button>
     </div>


### PR DESCRIPTION
Hi,

Finding that add color when inside a form is still submitting the form as per #87 

Here's how I'm using the code

```
<div class="color-selector"
                        [(colorPicker)]="colors.font"
                        [style.background]="colors.font"
                        [cpOutputFormat]="'rgba'"
                        [cpAlphaChannel]="'always'"
                        [cpPosition]="'left'"
                        [cpOKButton]="true"
                        [cpCancelButton]="true"
                        (colorPickerChange)="colors.font = $event"
                        (colorPickerSelect)="colors.font = $event; onInnerColorSelected($event)"
                        [cpPresetColors]="colors.presets"
                        [cpAddColorButton]="true"
                        (cpPresetColorsChange)="onPresetChange($event)">
                    </div>
```

Managed to fix the issue by adding `type="button"` to the button.