### PR TITLE
Use "display" property instead of "visibility" property.

### DIFF
--- a/src/lib/color-picker.component.html
+++ b/src/lib/color-picker.component.html
@@ -1,4 +1,4 @@
-<div #dialogPopup class="color-picker" [style.visibility]="hidden || !show ? 'hidden' : 'visible'" [style.top.px]="top" [style.left.px]="left" [style.position]="position" [style.height.px]="cpHeight" [style.width.px]="cpWidth" (click)="$event.stopPropagation()">
+<div #dialogPopup class="color-picker" [style.display]="hidden || !show ? 'none' : 'block'" [style.top.px]="top" [style.left.px]="left" [style.position]="position" [style.height.px]="cpHeight" [style.width.px]="cpWidth" (click)="$event.stopPropagation()">
   <div *ngIf="cpDialogDisplay=='popup'" class="arrow arrow-{{cpPosition}}" [style.top.px]="arrowTop"></div>
 
   <div *ngIf="(cpColorMode || 1) === 1" class="saturation-lightness" [slider] [rgX]="1" [rgY]="1" [style.background-color]="hueSliderColor" (newValue)="onColorChange($event)" (dragStart)="onDragStart('saturation-lightness')" (dragEnd)="onDragEnd('saturation-lightness')">


### PR DESCRIPTION
To avoid an unnecessary white space at the bottom of the file, we can use "display" property instead of "visibility" property.