### PR TITLE
Add class for preset colors

### DIFF
--- a/src/lib/color-picker.component.html
+++ b/src/lib/color-picker.component.html
@@ -107,7 +107,7 @@
 
     <div class="preset-label">{{cpPresetLabel}}</div>
 
-    <div *ngIf="cpPresetColors?.length">
+    <div *ngIf="cpPresetColors?.length" class="{{cpPresetClass}}">
       <div *ngFor="let color of cpPresetColors" class="preset-color" [style.backgroundColor]="color" (click)="setColorFromString(color)">
         <span *ngIf="cpAddColorButton" class="{{cpRemoveColorButtonClass}}" (click)="onRemovePresetColor($event, color)"></span>
       </div>

--- a/src/lib/color-picker.component.ts
+++ b/src/lib/color-picker.component.ts
@@ -106,6 +106,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
   public cpPresetLabel: string;
   public cpPresetColors: string[];
   public cpMaxPresetColorsLength: number;
+  public cpPresetClass: string;
 
   public cpPresetEmptyMessage: string;
   public cpPresetEmptyMessageClass: string;
@@ -203,7 +204,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     cpOutputFormat: OutputFormat, cpDisableInput: boolean, cpIgnoredElements: any,
     cpSaveClickOutside: boolean, cpCloseClickOutside: boolean, cpUseRootViewContainer: boolean,
     cpPosition: string, cpPositionOffset: string, cpPositionRelativeToArrow: boolean,
-    cpPresetLabel: string, cpPresetColors: string[], cpMaxPresetColorsLength: number,
+    cpPresetLabel: string, cpPresetColors: string[], cpMaxPresetColorsLength: number, cpPresetClass: string,
     cpPresetEmptyMessage: string, cpPresetEmptyMessageClass: string, cpOKButton: boolean,
     cpOKButtonClass: string, cpOKButtonText: string, cpCancelButton: boolean,
     cpCancelButtonClass: string, cpCancelButtonText: string, cpAddColorButton: boolean,
@@ -250,6 +251,7 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
     this.fallbackColor = cpFallbackColor || '#fff';
 
     this.setPresetConfig(cpPresetLabel, cpPresetColors);
+    this.cpPresetClass = cpPresetClass;
 
     this.cpMaxPresetColorsLength = cpMaxPresetColorsLength;
     this.cpPresetEmptyMessage = cpPresetEmptyMessage;


### PR DESCRIPTION
Ability to add a class to the PresetColors `<div></div>`
For example scroll for all colors inside preset.
![scroll](https://user-images.githubusercontent.com/32811631/63591870-c027d100-c5b8-11e9-81e0-7844957fc7a1.png)
