### PR TITLE
enhancement: improve auto positioning #231

### DIFF
--- a/projects/app/src/app/app.component.html
+++ b/projects/app/src/app/app.component.html
@@ -288,6 +288,24 @@
 
   <div class="row">
     <div class="col-md-5">
+      <input cpPosition="auto" [value]="color18" [style.background]="color18" [(colorPicker)]="color18" />
+    </div>
+
+    <div class="col-md-7">
+      <p>Auto positioning:</p>
+      <pre>
+&lt;input [value]="color"
+       [style.background]="color"
+       cpPosition="auto"
+       [(colorPicker)]="color"/&gt;
+      </pre>
+    </div>
+  </div>
+
+  <hr>
+
+  <div class="row">
+    <div class="col-md-5">
       <input [value]="color14" [style.background]="color14" [cpAlphaChannel]="'always'" [cpOutputFormat]="'rgba'" [(colorPicker)]="color14"/>
 
       <br>

--- a/projects/app/src/app/app.component.ts
+++ b/projects/app/src/app/app.component.ts
@@ -40,7 +40,7 @@ export class AppComponent {
   public color15: string = 'rgb(255,0,0)';
   public color16: string = '#a51ad633';
   public color17: string = '#666666';
-  public color18: string = '#ff0000';
+  public color18: string = '#fa8072';
 
   public cmykValue: string = '';
 

--- a/projects/lib/src/lib/color-picker.component.ts
+++ b/projects/lib/src/lib/color-picker.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, OnDestroy, AfterViewInit,
   ViewChild, HostListener, ViewEncapsulation,
   ElementRef, ChangeDetectorRef } from '@angular/core';
 
-import { detectIE } from './helpers';
+import { detectIE, calculateAutoPositioning } from './helpers';
 
 import { ColorFormats, Cmyk, Hsla, Hsva, Rgba } from './formats';
 import { AlphaChannel, OutputFormat, SliderDimension, SliderPosition } from './helpers';
@@ -978,35 +978,9 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
       let usePosition = this.cpPosition;
 
       if (this.cpPosition === 'auto') {
-        let usePositionX = 'right';
-        let usePositionY = 'bottom';
-   
-        const bounds = this.dialogElement.nativeElement.getBoundingClientRect();
-
-        // Top is out of viewport
-        if (bounds.top < 0) {
-          usePositionY = 'bottom';
-        }
-        
-        // Left side is out of viewoprt
-        if (bounds.left < 0) {
-          usePositionX = 'right';
-        }
-        
-        // Bottom is out of viewport
-        if (bounds.bottom > (window.innerHeight || document.documentElement.clientHeight)) {
-          usePositionY = 'top';
-        }
-        
-        // Right side is out of viewport
-        if (bounds.right > (window.innerWidth || document.documentElement.clientWidth)) {
-          usePositionX = 'left';
-        }
-
-        usePosition = usePositionX + '-' + usePositionY;
+        const dialogBounds = this.dialogElement.nativeElement.getBoundingClientRect();
+        usePosition = calculateAutoPositioning(dialogBounds);
       }
-
-      this.cpUsePosition = usePosition;
 
       if (usePosition === 'top') {
         this.arrowTop = dialogHeight - 1;

--- a/projects/lib/src/lib/color-picker.component.ts
+++ b/projects/lib/src/lib/color-picker.component.ts
@@ -980,16 +980,27 @@ export class ColorPickerComponent implements OnInit, OnDestroy, AfterViewInit {
       if (this.cpPosition === 'auto') {
         let usePositionX = 'right';
         let usePositionY = 'bottom';
+   
+        const bounds = this.dialogElement.nativeElement.getBoundingClientRect();
 
-        const winWidth = Math.max(document.documentElement.clientWidth, window.innerWidth || 0);
-        const winHeight = Math.max(document.documentElement.clientHeight, window.innerHeight || 0);
-
-        if (this.left + this.cpWidth > winWidth) {
-          usePositionX = 'left';
+        // Top is out of viewport
+        if (bounds.top < 0) {
+          usePositionY = 'bottom';
         }
-
-        if (this.top + dialogHeight > winHeight) {
+        
+        // Left side is out of viewoprt
+        if (bounds.left < 0) {
+          usePositionX = 'right';
+        }
+        
+        // Bottom is out of viewport
+        if (bounds.bottom > (window.innerHeight || document.documentElement.clientHeight)) {
           usePositionY = 'top';
+        }
+        
+        // Right side is out of viewport
+        if (bounds.right > (window.innerWidth || document.documentElement.clientWidth)) {
+          usePositionX = 'left';
         }
 
         usePosition = usePositionX + '-' + usePositionY;

--- a/projects/lib/src/lib/helpers.ts
+++ b/projects/lib/src/lib/helpers.ts
@@ -5,7 +5,68 @@ export type ColorMode = 'color' | 'c' | '1' |
 
 export type AlphaChannel = 'enabled' | 'disabled' | 'always' | 'forced';
 
+export type BoundingRectangle = {
+  top: number;
+  bottom: number;
+  left: number;
+  right: number;
+  height: number;
+  width: number;
+}
+
 export type OutputFormat = 'auto' | 'hex' | 'rgba' | 'hsla';
+
+export function calculateAutoPositioning(elBounds: BoundingRectangle): string {
+  // Defaults
+  let usePositionX = 'right';
+  let usePositionY = 'bottom';
+
+  // Calculate collisions
+  const { height, width, top, bottom, left, right } = elBounds;
+  const collisionTop = top - height < 0;
+  const collisionBottom = bottom + height > (window.innerHeight || document.documentElement.clientHeight);
+  const collisionLeft = left - width < 0;
+  const collisionRight = right + width > (window.innerWidth || document.documentElement.clientWidth);
+  const collisionAll = collisionTop && collisionBottom && collisionLeft && collisionRight;
+
+  // Generate X & Y position values
+  if (collisionBottom) {
+    usePositionY = 'top';
+  }
+
+  if (collisionTop) {
+    usePositionY = 'bottom';
+  }
+
+  if (collisionLeft) {
+    usePositionX = 'right';
+  }
+  
+  if (collisionRight) {
+    usePositionX = 'left';
+  }
+
+
+  // Choose the largest gap available
+  if (collisionAll) {
+    const postions = ['left', 'right', 'top', 'bottom'];
+    return postions.reduce((prev, next) => elBounds[prev] > elBounds[next] ? prev : next);
+  }
+
+  if ((collisionLeft && collisionRight)) {
+    if (collisionTop) return 'bottom';
+    if (collisionBottom) return 'top';
+    return top > bottom ? 'top' : 'bottom';
+  }
+
+  if ((collisionTop && collisionBottom)) {
+    if (collisionLeft) return 'right';
+    if (collisionRight) return 'left';
+    return left > right ? 'left' : 'right';
+  }
+
+  return `${usePositionY}-${usePositionX}`;
+}
 
 export function detectIE(): boolean | number {
   let ua = '';


### PR DESCRIPTION
Needed a quick fix for a project, not sure if you wanted to address some other way

- addresses issue where setting `cpPosition` to `auto` could render the picker off screen. (#231) 
- use dialog element's boundRect values to calculate collisions with the view port
- render picker in largest available area

![CleanShot 2020-09-24 at 00 52 47](https://user-images.githubusercontent.com/4476373/94038492-7768ca00-fe01-11ea-9861-2274710b0569.gif)

