### PR TITLE
perf: tree-shake `ReflectiveInjector` and warning

### DIFF
--- a/projects/lib/src/lib/color-picker.module.ts
+++ b/projects/lib/src/lib/color-picker.module.ts
@@ -7,6 +7,8 @@ import { ColorPickerService } from './color-picker.service';
 import { ColorPickerComponent } from './color-picker.component';
 import { ColorPickerDirective } from './color-picker.directive';
 
+import './ng-dev-mode';
+
 @NgModule({
   imports: [ CommonModule ],
   exports: [ ColorPickerDirective ],

--- a/projects/lib/src/lib/color-picker.service.ts
+++ b/projects/lib/src/lib/color-picker.service.ts
@@ -8,8 +8,6 @@ import { ColorPickerComponent } from './color-picker.component';
 export class ColorPickerService {
   private active: ColorPickerComponent | null = null;
 
-  constructor() {}
-
   public setActive(active: ColorPickerComponent | null): void {
     if (this.active && this.active !== active && this.active.cpDialogDisplay !== 'inline') {
       this.active.closeDialog();

--- a/projects/lib/src/lib/ng-dev-mode.ts
+++ b/projects/lib/src/lib/ng-dev-mode.ts
@@ -1,0 +1,8 @@
+/** @internal */
+declare global {
+  // Will be provided through Terser global definitions by Angular CLI during the
+  // production build. This is how Angular does tree-shaking internally.
+  const ngDevMode: boolean;
+}
+
+export {};

--- a/projects/lib/tsconfig.json
+++ b/projects/lib/tsconfig.json
@@ -5,6 +5,7 @@
     "target": "es2015",
     "declaration": true,
     "inlineSources": true,
+    "stripInternal": true,
     "types": [],
     "lib": [
       "dom",


### PR DESCRIPTION
The `ReflectiveInjector` has been deprecated long time ago and shouldn't be bundled with that package.