### PR TITLE
fix(316, 326, 256, 252, 243, and more): provide color-picker service in root

### DIFF
--- a/projects/lib/src/lib/color-picker.module.ts
+++ b/projects/lib/src/lib/color-picker.module.ts
@@ -12,7 +12,6 @@ import './ng-dev-mode';
 @NgModule({
   imports: [ CommonModule ],
   exports: [ ColorPickerDirective ],
-  providers: [ ColorPickerService ],
   declarations: [ ColorPickerComponent, ColorPickerDirective, TextDirective, SliderDirective ]
 })
 export class ColorPickerModule {}

--- a/projects/lib/src/lib/color-picker.service.ts
+++ b/projects/lib/src/lib/color-picker.service.ts
@@ -4,7 +4,9 @@ import { Cmyk, Rgba, Hsla, Hsva } from './formats';
 
 import { ColorPickerComponent } from './color-picker.component';
 
-@Injectable()
+@Injectable({
+  providedIn: 'root'
+})
 export class ColorPickerService {
   private active: ColorPickerComponent | null = null;
 


### PR DESCRIPTION
Does the ColorPickerService really need to have different instances ? If not, provide it in `root` will solve a lot of issues.

## PR Type
What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:


## What is the current behavior?
No value is set in the `@Injectable()` decorator.

Issue Number: fixes #316, #326, #256, #252, #243 
## What is the new behavior?
`@Injectable` decorator is now `providedIn: 'root'`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
