### PR TITLE
feature: allow cpAlphaChannel to be changed after initialization

### DIFF
--- a/projects/app/src/app/app.component.html
+++ b/projects/app/src/app/app.component.html
@@ -345,6 +345,14 @@
 
       <input [value]="color15" [style.background]="color15" [cpAlphaChannel]="'forced'" [cpOutputFormat]="'hex'" [(colorPicker)]="color15"/>
 
+      <br>
+
+      <label>
+        Alpha enabled:
+        <input type="checkbox" [(ngModel)]="alphaEnabled"/>
+      </label>
+      <input [value]="color20" [style.background]="color20" [cpAlphaChannel]="alphaEnabled ? 'always' : 'disabled'" [cpOutputFormat]="'hex'" [(colorPicker)]="color20"/>
+
     </div>
 
     <div class="col-md-7">
@@ -372,6 +380,12 @@
 &lt;input [value]="color"
        [style.background]="color"
        [cpAlphaChannel]="'forced'"
+       [cpOutputFormat]="'hex'"
+       [(colorPicker)]="color"/&gt;
+
+&lt;input [value]="color"
+       [style.background]="color"
+       [cpAlphaChannel]="alphaEnabled ? 'always' : 'disabled'"
        [cpOutputFormat]="'hex'"
        [(colorPicker)]="color"/&gt;
       </pre>
@@ -461,15 +475,14 @@
         </div>
         <hr><br>
 
-        <div class="row">
-            <div class="col-md-12">
-                <table class="table">
-                    <thead>
-                    <tr>
-                        <th>Options</th>
-                        <th>Values (default values in bold)</th>
-                    </tr>
-                    </thead>
+        <div class="col-md-12">
+          <table class="table">
+            <thead>
+            <tr>
+                <th>Options</th>
+                <th>Values (default values in bold)</th>
+            </tr>
+            </thead>
 
         <tbody>
           <tr>

--- a/projects/app/src/app/app.component.ts
+++ b/projects/app/src/app/app.component.ts
@@ -42,10 +42,13 @@ export class AppComponent {
   public color17: string = '#666666';
   public color18: string = '#fa8072';
   public color19: string = '#f88888';
+  public color20: string = '#ff0000';
 
   public cmykValue: string = '';
 
   public cmykColor: Cmyk = new Cmyk(0, 0, 0, 0);
+
+  public alphaEnabled = false;
 
   constructor(public vcRef: ViewContainerRef, private cpService: ColorPickerService) {}
 

--- a/projects/app/src/app/app.module.ts
+++ b/projects/app/src/app/app.module.ts
@@ -1,4 +1,5 @@
 import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
 import { BrowserModule } from '@angular/platform-browser';
 
 import { ColorPickerModule } from 'ngx-color-picker';
@@ -14,7 +15,8 @@ import { AppComponent } from './app.component';
   ],
   imports: [
     BrowserModule,
-    ColorPickerModule
+    ColorPickerModule,
+    FormsModule,
   ]
 })
 export class AppModule {}

--- a/projects/lib/src/lib/color-picker.directive.ts
+++ b/projects/lib/src/lib/color-picker.directive.ts
@@ -226,6 +226,10 @@ export class ColorPickerDirective implements OnChanges, OnDestroy {
         this.cmpRef.changeDetectorRef.detectChanges();
       }
     } else if (this.dialog) {
+      // Update properties.
+      this.cmpRef.instance.cpAlphaChannel = this.cpAlphaChannel;
+
+      // Open dialog.
       this.dialog.openDialog(this.colorPicker);
     }
   }


### PR DESCRIPTION
### PR Type
What kind of change does this PR introduce?

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

### What is the current behavior?
Opening the color picker dialog will use the initial `cpAlphaChannel` value. Assigning it to a variable will not work.

Example:
```
<input [value]="color"
       [style.background]="color"
       [cpAlphaChannel]="alphaEnabled ? 'always' : 'disabled'"
       [cpOutputFormat]="'hex'"
       [(colorPicker)]="color"/>
```

### What is the new behavior?
The color picker dialog will update its `cpAlphaChannel` before opening. This will make the `cpAlphaChannel` option more reactive. This allows the color picker to be used with a dropdown / checkbox which decides whether alpha should be enabled/disabled (on the same page).
