### PR TITLE
Add 'repository' to lib's package.json

### DIFF
--- a/projects/lib/package.json
+++ b/projects/lib/package.json
@@ -1,6 +1,11 @@
 {
   "name": "ngx-color-picker",
   "description": "Color picker widget for Angular",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zefoy/ngx-color-picker.git",
+    "directory": "projects/lib"
+  },
   "bugs": "https://github.com/zefoy/ngx-color-picker/issues",
   "version": "16.0.0",
   "license": "MIT",


### PR DESCRIPTION
Although this field is present in the 'upper' package.json, it is not present on the package.json after running `ng build lib`. As a consequence, it is not detected by Angular CLI when informing of errors about the project, and one also cannot go to this repository from the NPM package page.